### PR TITLE
Adopt GitHub Actions

### DIFF
--- a/.cisupport/post.sh
+++ b/.cisupport/post.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Post Installation Check
+
+kernel_name=$(uname -s)
+
+echo "kernel_name:$kernel_name"
+
+if [ "$kernel_name" == "Darwin" ]; then
+    brew list --versions
+    brew list --cask --versions
+
+elif [ "$kernel_name" == "Linux" ]; then
+    echo "TODO: Figure out what to check for Linux"
+fi

--- a/.cisupport/pre.sh
+++ b/.cisupport/pre.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Pre Installation Check
+
+kernel_name=$(uname -s)
+
+echo "kernel_name:$kernel_name"
+
+if [ "$kernel_name" == "Darwin" ]; then
+    brew --version
+    sw_vers
+
+elif [ "$kernel_name" == "Linux" ]; then
+    # https://kinsta.com/knowledgebase/check-ubuntu-version/
+    cat /etc/issue
+    hostnamectl
+fi
+
+curl --version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,47 @@
+name: CI Tests
+on:
+  push:
+    paths:
+      - "*"
+  pull_request:
+    branches:
+      - "main" 
+jobs:
+
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+
+  tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@main
+
+      - name: Run bin/doi
+        run: bash bin/doi
+
+      - name: Verify base packages are installed
+        run: |
+          command -v ansible
+
+      # - name: Test script/setup
+      #   run: bash script/setup
+
+      # - name: Test bashrc
+      #   run: bash -xc "source ~/.bashrc"
+
+      - name: Verify base packages are installed (MacOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          command -v brew

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,13 +8,13 @@ on:
       - "main" 
 jobs:
 
-  shellcheck:
-    name: Shellcheck
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
+  # shellcheck:
+  #   name: Shellcheck
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Run ShellCheck
+  #       uses: ludeeus/action-shellcheck@master
 
   tests:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - "main" 
+
 jobs:
 
   # shellcheck:
@@ -19,29 +20,26 @@ jobs:
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
+      # cancel all in-progress and queued jobs in the matrix if any job in the matrix fails
       fail-fast: true
       matrix:
         os:
           - ubuntu-latest
           - macos-latest
+
     steps:
-      - name: Set up Git repository
-        uses: actions/checkout@main
+      - uses: actions/checkout@main
 
-      - name: Run bin/doi
-        run: bash bin/doi
+      - name: Check versions of pre-installed software/system
+        run: ./.cisupport/pre.sh
 
-      - name: Verify base packages are installed
+      - name: Install and verify packages are installed
+        working-directory: bin
         run: |
+          pwd
+          bash doi -t neovim
           command -v ansible
+          command -v nvim
 
-      # - name: Test script/setup
-      #   run: bash script/setup
-
-      # - name: Test bashrc
-      #   run: bash -xc "source ~/.bashrc"
-
-      - name: Verify base packages are installed (MacOS)
-        if: matrix.os == 'macos-latest'
-        run: |
-          command -v brew
+      - name: Check installed versions 
+        run: ./.cisupport/post.sh

--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,6 @@ list-ansible-tags:		## list ansible tags
 
 zsh-sections:		## display zshrc sections
 	rg '<<<|>>>' ~/zsh/.zshrc
+
+ci: 		## CI - Github Actions Test
+	act push

--- a/bin/common-utilities.sh
+++ b/bin/common-utilities.sh
@@ -99,3 +99,19 @@ function finished() {
 
 # print_info "Parent Directory:'$PARENT_DIR'"
 # print_info "Dotfiles Directory:'$DOTFILES_DIR'"
+
+# Github CI
+# Inspired by https://github.com/mattorb/dotfiles/blob/master/.github/workflows/install.yml
+# https://mattorb.com/ci-your-dotfiles-with-github-actions/
+
+is_ci() {
+    # Running inside a GITHUB Action build
+    [ ${GITHUB_ACTION} ] && return 0
+    
+    # # Running inside an Azure DevOps pipeline
+    # if [ "$TF_BUILD" == "True" ]; then
+    #  return 0
+    # fi
+    
+    return 1
+}

--- a/bin/doi
+++ b/bin/doi
@@ -9,11 +9,26 @@
 #
 ##########################################################################
 
+
 set -e
 
-source "${HOME}/.dotfiles/bin/common-utilities.sh"
+if test -f common-utilities.sh; then
+    source common-utilities.sh
+else
+    source "${HOME}/.dotfiles/bin/common-utilities.sh"
+fi
 
-ANSIBLE_DIR="${HOME}/.dotfiles"
+
+if is_ci; then
+    echo "Running in CI"
+    ANSIBLE_DIR="../"
+else
+    echo "Running normally!"
+    ANSIBLE_DIR="${HOME}/.dotfiles"
+fi
+
+echo "Ansible_dir:$ANSIBLE_DIR"
+
 PLAYBOOK_FILE="${ANSIBLE_DIR}/dotfiles.yml"
 HOSTS_FILE="${ANSIBLE_DIR}/hosts"
 

--- a/docs/github-actions-learnings.md
+++ b/docs/github-actions-learnings.md
@@ -1,0 +1,14 @@
+# Github Actions Learnings
+
+The biggest learning/change was the renaming of my repo to `.dotfiles`.
+
+Why? Because I cloned my `dotfiles` repo to a local directory called `.dotfiles` and all scripts were set up to run under the `.dotfiles/` directory. This caused issues as Github Action runners checked out the `dotfiles` repo and that's where the scripts were called from.
+
+Googling around led me to this [issue](https://github.com/actions/checkout/issues/197#) (open as of Sep 2023) and this [issue comment](https://github.com/actions/checkout/issues/197#issuecomment-829560171) where someone successfully renamed their repo by copying it over.
+
+After some trial and error, the easiest solution was simply to rename my repo to from `dotfiles` to `.dotfiles`. This would make it consistent everywhere else and simplify my adoption of Github Actions. Github Action runners would check out the same directory and scripts would run with no issues 🎉 A simple fix to a silly solution.
+
+Second learning was something I came across was from the below article on using Github Actions for continuous integration of MacOS based dotfiles. Specifically, the use of environment variables and determining where you were running.
+
+- [CI your MacOS dotfiles with GitHub Actions!](https://mattorb.com/ci-your-dotfiles-with-github-actions/)
+- [dotfiles repo](https://github.com/mattorb/dotfiles/tree/master)

--- a/roles/cli/common-cli/tasks/act.yml
+++ b/roles/cli/common-cli/tasks/act.yml
@@ -1,0 +1,16 @@
+---
+# https://github.com/nektos/act
+
+- name: ACT - act is present
+
+  block:
+    - name: ACT - Install via homebrew
+      when: ansible_os_family in ["Darwin"]
+      homebrew:
+        name: act
+        state: present
+
+    - name: ACT - install for debian from the internet
+      when: ansible_os_family in ["Debian",  "Pop!_OS" ]
+      debug:
+        msg: "TODO: Implement for Ubuntu"


### PR DESCRIPTION
Adopt Github Actions to assist in verifying initial installation via `doi` script for both Linux and MacOS environments.

**Changes**

- Add New Github Action which runs tests on both Linux and MacOS environments in parallel
- Add helper scripts under `.cisupport/`
- Update `doi` to dynamically source files and specify directories depending where it is running
- Update Makefile with `ci` command to run GIthub Actions locally via [act](https://github.com/nektos/act)
- Write up short learnings documentation
- Update `common-cli` role to install `act` tool for MacOS (Do later for Ubuntu)