### PR TITLE
Add Shellcheck for Static Code Analysis

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,13 +9,18 @@ on:
 
 jobs:
 
-  # shellcheck:
-  #   name: Shellcheck
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Run ShellCheck
-  #       uses: ludeeus/action-shellcheck@master
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        # only scan files in `bin/` ignoring icalBuddy file (since its an executable)
+        with:
+          scandir: './bin'
+          ignore_names: >-
+            icalBuddy
 
   tests:
     runs-on: ${{ matrix.os }}

--- a/bin/andys-script.sh
+++ b/bin/andys-script.sh
@@ -7,7 +7,7 @@ if [[ ! -e $my_file ]]; then
 fi
 
 number_of_profiles=4
-term_counter=$(cat ${my_file})
-gnome-terminal --window-with-profile=RedPanda${term_counter}
-let term_counter="(term_counter + 1) % ${number_of_profiles}"
+term_counter=$(cat "${my_file}")
+gnome-terminal --window-with-profile=RedPanda"${term_counter}"
+term_counter="(term_counter + 1) % ${number_of_profiles}"
 echo "$term_counter" > "$my_file"

--- a/bin/assume-aws-role.sh
+++ b/bin/assume-aws-role.sh
@@ -13,11 +13,11 @@ fi
 role_arn=$1
 role_session_name=$2
 
-resp=$(aws sts assume-role --role-arn $role_arn --role-session-name $role_session_name)
+resp=$(aws sts assume-role --role-arn "$role_arn" --role-session-name "$role_session_name")
 
-RoleAccessKeyID=$(echo $resp | jq -r '.Credentials.AccessKeyId')
-RoleSecretKey=$(echo $resp | jq -r '.Credentials.SecretAccessKey')
-RoleSessionToken=$(echo $resp | jq -r '.Credentials.SessionToken')
+RoleAccessKeyID=$(echo "$resp" | jq -r '.Credentials.AccessKeyId')
+RoleSecretKey=$(echo "$resp" | jq -r '.Credentials.SecretAccessKey')
+RoleSessionToken=$(echo "$resp" | jq -r '.Credentials.SessionToken')
 
 
 echo "Assume role $role_arn:

--- a/bin/check-github-software-for-updates.sh
+++ b/bin/check-github-software-for-updates.sh
@@ -7,6 +7,7 @@
 #
 ###################################################################
 
+# shellcheck source=/dev/null
 source "${HOME}/.dotfiles/bin/common-utilities.sh"
 
 CONFIG_FILE="${DOTFILES_DIR}/ansible/group_vars/all/github.yml"

--- a/bin/common-utilities.sh
+++ b/bin/common-utilities.sh
@@ -18,25 +18,30 @@ LINE_BREAK="--------------------------------------------------------------------
 PARENT_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd -P)"
 DOTFILES_DIR="$(cd "$( dirname "$PARENT_DIR" )" && pwd -P)"
 
+export SCRIPT_BREAK LINE_BREAK DOTFILES_DIR
 
 # COLORS
-default="\033[39m"
-black="\033[30m"
-red="\033[0;31m"
-green="\033[32m"
-yellow="\033[33m"
-blue="\033[34m"
-magenta="\033[35m"
-cyan="\033[36m"
-light_gray="\033[37m"
-dark_gray="\033[90m"
-light_red="\033[91m"
-light_green="\033[92m"
-light_yellow="\033[93m"
-light_blue="\033[94m"
-light_magenta="\033[95m"
-light_cyan="\033[96m"
-white="\033[97m"
+DEFAULT="\033[39m"
+BLACK="\033[30m"
+RED="\033[0;31m"
+GREEN="\033[32m"
+YELLOW="\033[33m"
+BLUE="\033[34m"
+MAGENTA="\033[35m"
+CYAN="\033[36m"
+LIGHT_GRAY="\033[37m"
+DARK_GRAY="\033[90m"
+LIGHT_RED="\033[91m"
+LIGHT_GREEN="\033[92m"
+LIGHT_YELLOW="\033[93m"
+LIGHT_BLUE="\033[94m"
+LIGHT_MAGENTA="\033[95m"
+LIGHT_CYAN="\033[96m"
+WHITE="\033[97m"
+
+export DEFAULT BLACK RED GREEN YELLOW BLUE MAGENTA CYAN LIGHT_GRAY DARK_GRAY LIGHT_RED \
+    LIGHT_GREEN LIGHT_YELLOW LIGHT_BLUE LIGHT_MAGENTA LIGHT_CYAN WHITE
+
 
 
 # FUNCTIONS
@@ -44,54 +49,62 @@ white="\033[97m"
 
 function convert_seconds_to_min() {
     runtime_seconds=$1
-    printf %.2f\\n $(echo $runtime_seconds / 60 | bc -l)
+    printf %.2f\\n "$(echo "$runtime_seconds" / 60 | bc -l)"
+    # echo %.2f\\n $(echo $runtime_seconds / 60 | bc -l)
 }
 
 
 # >>> OUTPUT DISPLAY FUNCTIONS
 
 function print_stamp() {
-    echo -e "\n$(date +'%F %T') $@";
+    echo -e "\n$(date +'%F %T') $*";
 }
 
 
 function print_info() {
-    printf "$(date +'%F %T')  [ \033[00;34m..\033[0m ] $1\n"
+    # printf "$(date +'%F %T')  [ \033[00;34m..\033[0m ] $1\n"
+    echo -e "$(date +'%F %T')  [ \033[00;34m..\033[0m ] $1"
 }
 
 
 function user() {
-    printf "$(date +'%F %T')  [ \033[0;33m??\033[0m ] $1\n"
+    # printf "$(date +'%F %T')  [ \033[0;33m??\033[0m ] $1\n"
+    echo -e "$(date +'%F %T')  [ \033[0;33m??\033[0m ] $1"
 }
 
 
 function success() {
-    printf "\033[2K$(date +'%F %T')  [ \033[00;32mOK\033[0m ] $1\n"
+    # printf "\033[2K$(date +'%F %T')  [ \033[00;32mOK\033[0m ] $1\n"
+    echo -e "\033[2K$(date +'%F %T')  [ \033[00;32mOK\033[0m ] $1"
 }
 
 
 function fail() {
-    printf "\033[2K$(date +'%F %T')  [\033[0;31mFAIL\033[0m] $1\n"
-    echo ''
+    # printf "\033[2K$(date +'%F %T')  [\033[0;31mFAIL\033[0m] $1\n"
+    echo -e "\033[2K$(date +'%F %T')  [\033[0;31mFAIL\033[0m] $1\n"
+    # echo ''
     exit
 }
 
 
 function warn() {
-    printf "\033[2K$(date +'%F %T')  [\033[0;31mWARN\033[0m] $1\n"
-    echo ''
+    # printf "\033[2K$(date +'%F %T')  [\033[0;31mWARN\033[0m] $1\n"
+    echo -e "\033[2K$(date +'%F %T')  [\033[0;31mWARN\033[0m] $1\n"
+    # echo ''
 }
 
 
 function start() {
-    printf "\033[2K$(date +'%F %T')  [\033[0;36mSTART\033[0m] $1\n"
+    # printf "\033[2K$(date +'%F %T')  [\033[0;36mSTART\033[0m] $1\n"
+    echo -e "\033[2K$(date +'%F %T')  [\033[0;36mSTART\033[0m] $1\n"
     echo ''
 }
 
 
 function finished() {
-    printf "\033[2K$(date +'%F %T')  [\033[0;36mDONE\033[0m] $1\n"
-    echo ''
+    # printf "\033[2K$(date +'%F %T')  [\033[0;36mDONE\033[0m] $1\n"
+    echo -e "\033[2K$(date +'%F %T')  [\033[0;36mDONE\033[0m] $1\n"
+    # echo ''
 }
 
 # <<< OUTPUT DISPLAY FUNCTIONS
@@ -106,7 +119,7 @@ function finished() {
 
 is_ci() {
     # Running inside a GITHUB Action build
-    [ ${GITHUB_ACTION} ] && return 0
+    [ "${GITHUB_ACTION}" ] && return 0
     
     # # Running inside an Azure DevOps pipeline
     # if [ "$TF_BUILD" == "True" ]; then

--- a/bin/convert-md-to-mediawiki.sh
+++ b/bin/convert-md-to-mediawiki.sh
@@ -5,8 +5,8 @@
 echo 'hello'
 
 input_file=$1
-output_file="$(basename $input_file .md).mediawiki"
+output_file="$(basename "$input_file" .md).mediawiki"
 
 echo "Converting '${input_file}' to '${output_file}'..."
 
-pandoc -f markdown -t mediawiki < $input_file > $output_file
+pandoc -f markdown -t mediawiki < "$input_file" > "$output_file"

--- a/bin/create-ami.sh
+++ b/bin/create-ami.sh
@@ -60,7 +60,7 @@ print_stamp "Script $0 Started"
 description="${name}-$(date +"%Y-%m-%d_%H:%M:%S")"
 echo "Description:'$description'"
 
-aws --profile $profile s3 ls
+aws --profile "$profile" s3 ls
 #aws --profile $profile create-image --instance-id $instance-id --name $name --no-reboot
 
 print_stamp "Script $0 Completed"

--- a/bin/create-github-ssh-key
+++ b/bin/create-github-ssh-key
@@ -3,15 +3,15 @@
 # Create Github SSH Key
 
 echo "Please enter the value for ssh_key_filename (default:id_rsa_personal_github)"
-read ssh_key_filename
+read -r ssh_key_filename
 ssh_key_filename="${ssh_key_filename:-id_rsa_personal_github}"
 
 echo "Please enter the value for email"
-read email
+read -r email_address
 
 echo -e "\n
     ssh_key_file_name:$ssh_key_filename
-    email:$email\n"
+    email:$email_address\n"
 
 file="$HOME/.ssh/$ssh_key_filename"
 
@@ -19,9 +19,9 @@ if [[ -f "$file" ]]; then
     echo "WARNING: File $file already exists. Skipping creating it"
 else
     echo "Creating new ssh key"
-    ssh-keygen -t ed25519 -C "$email_address" -f $file
+    ssh-keygen -t ed25519 -C "$email_address" -f "$file"
 fi
 
 gh auth login
 
-gh ssh-key add $file.pub
+gh ssh-key add "$file".pub

--- a/bin/doi
+++ b/bin/doi
@@ -12,6 +12,7 @@
 
 set -e
 
+# shellcheck source=/dev/null
 if test -f common-utilities.sh; then
     source common-utilities.sh
 else
@@ -23,7 +24,6 @@ if is_ci; then
     echo "Running in CI"
     ANSIBLE_DIR="../"
 else
-    echo "Running normally!"
     ANSIBLE_DIR="${HOME}/.dotfiles"
 fi
 
@@ -34,18 +34,19 @@ HOSTS_FILE="${ANSIBLE_DIR}/hosts"
 
 
 function usage() {
-    echo -e "${red}ERROR: Script requires the following inputs:
-    ${blue}
+    echo -e "${RED}ERROR: Script requires the following inputs:
+    ${BLUE}
     -f: find tag
-    -t: tag for ansible (default: all)
+    -t: tag for ansible (DEFAULT: all)
     -i: get info for an aggregate tag (tags with multiple packages. e.g. macos-cli, macos-infra)
     -a: enable ask_become_pass
     "
-    echo -e "${yellow}Usage:
-        ${0##*/} # will display all available tags
-        ${0##*/} -t zsh -a
-        ${0##*/} -f macos
-        "
+    echo -e "${YELLOW}Usage:
+    ${0##*/} # will display all available tags
+    ${0##*/} -t zsh -a
+    ${0##*/} -t meld,broot
+    ${0##*/} -f macos
+    "
 }
 
 
@@ -58,7 +59,7 @@ main() {
         case $opt in
             a  ) ask_become_pass="true" ;;
             f  ) to_find="$OPTARG" ;;
-            t  ) tags+=("$OPTARG") ;;
+            t  ) tags="$OPTARG" ;;
             i  ) to_info="$OPTARG" ;;
             h  ) usage; exit 0 ;;
             :  ) echo "Option -$OPTARG requires an argument." >&2; usage; exit 1 ;;
@@ -72,11 +73,8 @@ main() {
     print_info "$0 Started"
     
     print_info "playbook_file:${PLAYBOOK_FILE}"
-    print_info "tags before:'${tags[*]}'"
-    tags=$(echo "$tags" | sed 's/ /,/g')
-    print_info "tags after:'${tags}'"
     print_info "tags:'${tags}'"
-    print_info "ask_becomen_pass?${ask_become_pass}"
+    print_info "ask_become_pass?${ask_become_pass}"
 
     ensure_ansible_is_present
 
@@ -98,12 +96,14 @@ main() {
         exit 0
     fi
 
-    command_options=" ${PLAYBOOK_FILE} -i ${HOSTS_FILE} --tags ${tags[*]}"
+    command_options=" ${PLAYBOOK_FILE} -i ${HOSTS_FILE} --tags ${tags}"
     
     if [[ "$ask_become_pass" == "true" ]]; then
         command_options="${command_options} --ask-become-pass"
     fi
 
+    echo "ansible-playbook $command_options"
+    # shellcheck disable=SC2086
     ansible-playbook $command_options
  
     end=$(date +%s)
@@ -121,7 +121,7 @@ function search_for_tag() { # search for a tag
     tags=$(get_tags)
     found_tag=$(echo -e "$tags" | grep "$to_find")
     # TODO: Test alternative: grep -o $to_find | head -1
-    echo -e "\n${green}Found Tag(s):\n'$found_tag'"
+    echo -e "\n${GREEN}Found Tag(s):\n'$found_tag'"
 }
 
 function get_tags() {
@@ -139,17 +139,18 @@ function get_tag_info() { # get tag info
     tags=$(get_tags)
     found_info_tag=$(echo -e "$tags" | grep "$to_info")
     num_found_tags=$(echo "$found_info_tag" | wc -l | sed 's/ //g')
-    echo -e "\n${green}$num_found_tags Found Info Tag(s):\n$found_info_tag"
+    echo -e "\n${GREEN}$num_found_tags Found Info Tag(s):\n$found_info_tag"
     
     if [[ "$num_found_tags" != 1 ]]; then
-        echo -e "${red}ERROR: More than 1 tags found. Exiting with error"
+        echo -e "${RED}ERROR: More than 1 tags found. Exiting with error"
         exit 1
     fi
 
     find_directory "$to_info"
-    echo -e "Directory:${yellow}$directory"
+    echo -e "Directory:${YELLOW}$directory"
 
-    echo -e "\n${light_blue}Packages for '$to_info' tag:"
+    echo -e "\n${LIGHT_BLUE}Packages for '$to_info' tag:"
+    # shellcheck disable=SC2002
     cat "$directory/README.md" |\
         # grab lines with either '- ack' or '- [coreutils]'
         grep -E '(^\- \[\([^]]\+\)\]|^- )' |\
@@ -171,12 +172,12 @@ function find_directory() { # find directory
         cmd="fd"
     fi
 
-    if [ ! -x "$(command -v $cmd)" ]; then
-        echo -e "${red}ERROR: Ensure $cmd is installed via common-cli role"
+    if [ ! -x "$(command -v "$cmd")" ]; then
+        echo -e "${RED}ERROR: Ensure $cmd is installed via common-cli role"
         exit 1
     fi
 
-    directory=$($cmd "$to_info" $ANSIBLE_DIR)
+    directory=$($cmd "$to_info" "$ANSIBLE_DIR")
 }
 
 
@@ -212,9 +213,9 @@ function list_available_tags() { # lists available tags
     # and corresponding tag before it does clean up
     # to get the final <role_prefix>/<tag> format
     ######################################################
-    role_tags_sections=$(grep -v '#' $PLAYBOOK_FILE |\
+    role_tags_sections=$(grep -v '#' "$PLAYBOOK_FILE" |\
         grep -e 'role\|tag' |\
-        # remove all white space
+        # remove all WHITE space
         tr -d ' ' |\
         # ensure role and corresponding tags in same line
         # ref: https://unix.stackexchange.com/questions/389764/merge-next-line-with-previous-line
@@ -238,20 +239,20 @@ function list_available_tags() { # lists available tags
     for line in $role_tags_sections
     do
         if [[ $line == *"cli/"* ]]; then
-            tags="${tags}  ${light_yellow}${line#"cli/"}"
+            tags="${tags}  ${LIGHT_YELLOW}${line#"cli/"}"
         elif [[ $line == *"infrastructure/"* ]]; then
-            tags="${tags}  ${light_blue}${line#"infrastructure/"}"
+            tags="${tags}  ${LIGHT_BLUE}${line#"infrastructure/"}"
         elif [[ $line == *"software/"* ]]; then
-            tags="${tags}  ${light_green}${line#"software/"}"
+            tags="${tags}  ${LIGHT_GREEN}${line#"software/"}"
         else
-            tags="${tags}  ${magenta}${line}"
+            tags="${tags}  ${MAGENTA}${line}"
         fi
         tags="$tags\n"
     done
 
     echo -e "$tags"
-    echo -e "${light_gray}LEGEND: 
-    ${light_yellow}CLI  ${light_blue}INFRASTRUCTURE  ${light_green}SOFTWARE  ${magenta}MISC${default}"
+    echo -e "${LIGHT_GRAY}LEGEND: 
+    ${LIGHT_YELLOW}CLI  ${LIGHT_BLUE}INFRASTRUCTURE  ${LIGHT_GREEN}SOFTWARE  ${MAGENTA}MISC${DEFAULT}"
 
 }
 

--- a/bin/jqgrep
+++ b/bin/jqgrep
@@ -16,6 +16,7 @@ FLAGS=""
 #   shift
 # done
 
+# shellcheck disable=SC2034
 # Parse arguments:
 while getopts ":r:p:v" opt; do
   case $opt in
@@ -34,6 +35,7 @@ if [[ "$KEYS" == "" && "$VALUES" == "" ]]; then
 fi
 
 PATTERN="$1"
+# shellcheck disable=SC2034
 FILE="$2"
 if [[ "$PATTERN" == "" ]]; then
   echo "Usage: ${0##*/} [-c|-k|-v|-i|-m|-n|-p|-s|-x] pattern [json-files...]

--- a/bin/set-personal-github-remote-url
+++ b/bin/set-personal-github-remote-url
@@ -14,7 +14,7 @@
 PERSONAL_GITHUB_URL="github.com-personal"
 
 # HELPER FUNCTIONS
-function print_stamp() { echo -e "\n$(date +'%F %T') $@"; }
+function print_stamp() { echo -e "\n$(date +'%F %T') $*"; }
 
 print_stamp "$0 Started"
 
@@ -41,7 +41,11 @@ fi
 if [[ "$fetch_url" == *"https"* ]]
 then
     echo -e "\nWARN: Convert https to ssh"
-    new_ssh_url=$(echo "$fetch_url" | sed "s;https://github.com/johannes;git@github.com:johannes;")
+    # new_ssh_url=$(echo "$fetch_url" | sed "s;https://github.com/johannes;git@github.com:johannes;")
+    # TODO: Test and verify this!
+    # Convert https://github.com/johannesgiorgis/.dotfiles.git to
+    # git@github.com:johannesgiorgis/.dotfiles.git
+    new_ssh_url=${fetch_url/https:\/\/github.com\/johannes/git@github.com:johannes}
     # git remote set-url origin git@github.com:USERNAME/REPOSITORY.git
     echo "git remote set-url origin $new_ssh_url"
     exit 0
@@ -62,7 +66,9 @@ else
 	echo "Git will be set to the Personal Github URL"
 fi
 
-new_git_url=$(echo "$fetch_url" | sed "s/github.com/$PERSONAL_GITHUB_URL/g")
+# new_git_url=$(echo "$fetch_url" | sed "s/github.com/$PERSONAL_GITHUB_URL/g")
+# TODO: Test and verify this!
+new_git_url=${fetch_url//github.com/$PERSONAL_GITHUB_URL/}
 echo -e "\nNew Git URL:$new_git_url"
 
 echo -e '\nSET:\n'

--- a/docs/learnings-shellcheck.md
+++ b/docs/learnings-shellcheck.md
@@ -1,0 +1,71 @@
+# Learnings - Shellcheck
+
+## Unused variables
+
+Shellcheck found unused variables which is great from a debugging perspective 🎉
+
+## Bash Parameter Expansion for simplified replacement
+
+Shellcheck pointed out an opportunity to simplify a string replacement and after some debugging, I got it working exactly as I wanted.
+
+Below is the shellcheck output that led to this learning:
+
+```sh
+λ  shellcheck check-asdf-installed-for-updates.sh
+
+In check-asdf-installed-for-updates.sh line 52:
+            subversion_root=$(echo "$installed_version" | sed 's/[0-9]*$//')
+                              ^-- SC2001 (style): See if you can use ${variable//search/replace} instead.
+
+For more information:
+  https://www.shellcheck.net/wiki/SC2001 -- See if you can use ${variable//se...
+```
+
+Before we jump to what this line does, we should understand what this script is doing. I use the `asdf` tool to manage the various versions of my development tools - languages, frameworks, etc. It works via plugin system. You install a plugin, then you install a specific version of that plugin (e.g. install nodejs, then install nodejs `18.17.0`). These plugins and versions are codified via my existing ansible roles. When dealing with multiple languages/tools, it is hard to track when you need to update - this applies to major as well as minor versions.
+
+Which leads us to this troublesome line. This line is parsing a plugin version to check for any updated minor versions. Building on our nodejs example, we would want to see if `18.17.0` is indeed the latest minor version (spoilers - it's not - `18.17.1` is available). This line does exactly that. It changes `18.17.0` -> `18.17` which will be used to check for the latest `18.17.X` version.
+
+Now that we understand the context, shellcheck was pointing out this code could be simplified by using bash shell parameter expansions. The tricky part was figuring out how to get it to handle the last match, not the first nor all matches.
+
+Debugging in the terminal:
+
+```sh
+λ  i="3.9.9"
+# current working code getting us what we want
+λ  echo $i | sed 's/[0-9]*$//'
+3.9.
+# changing to bash parameter expansion with AS IS
+λ  echo ${i/[0-9]*$//}
+3.9.9
+# This changes first occurence
+λ  echo ${i/[0-9]//}
+/.9.9
+# $ which is used to anchor to ending doesn't work
+λ  echo ${i/[0-9]$//}
+3.9.9
+
+# // is used to replace all matches
+λ  echo ${i//[0-9]/X}
+X.X.X
+
+# Googling around led to looking at bash shell parameter expansion docs
+λ  echo ${i//%[0-9]/X}
+3.9.X
+
+# Correct Ouput 🎉
+λ  echo ${i//%[0-9]/}
+3.9. 
+```
+
+From docs:
+
+```sh
+# If pattern is preceded by ‘%’ (the fourth form above), it must match at the end of the expanded value of parameter.
+${parameter/#pattern/string}
+```
+
+## References
+
+- [Shellcheck Wiki - SC2001](https://www.shellcheck.net/wiki/SC2001)
+- [StackOverfow Question/Answer](https://stackoverflow.com/a/13210909)
+- [Bash Shell Parameter Expansion](https://www.gnu.org/software/bash/manual/bash.html#Shell-Parameter-Expansion)

--- a/files/zsh/.zshrc
+++ b/files/zsh/.zshrc
@@ -103,7 +103,9 @@ is_plugin() {
 # Add all defined plugins to fpath. This must be done
 # before running compinit.
 OMZ_DIR="$ZDOTDIR/ohmyzsh"
-for plugin ($plugins); do
+
+for plugin in $plugins
+do
     if is_plugin "$ZDOTDIR" "$plugin"; then
         fpath=("$ZDOTDIR/plugins/$plugin" $fpath)
     elif is_plugin "$OMZ_DIR" "$plugin"; then
@@ -114,7 +116,8 @@ for plugin ($plugins); do
 done
 
 # Load all of the plugins that were defined in ~/.zshrc
-for plugin ($plugins); do
+for plugin in $plugins
+do
     if [[ -f "$ZDOTDIR/plugins/$plugin/$plugin.plugin.zsh" ]]; then
         source "$ZDOTDIR/plugins/$plugin/$plugin.plugin.zsh"
     elif [[ -f "$OMZ_DIR/plugins/$plugin/$plugin.plugin.zsh" ]]; then
@@ -405,6 +408,7 @@ function zsh_stats() {
 # take functions
 
 # mkcd is equivalent to takedir
+# shellcheck disable=SC1064,SC1072,SC1073
 function mkcd takedir() {
   mkdir -p $@ && cd ${@:$#}
 }


### PR DESCRIPTION
Add [shellcheck](https://www.shellcheck.net/) to perform static code analysis of bash scripts.

> ShellCheck, a static analysis tool for shell scripts. It finds bugs in your shell scripts.

**Changes**
- Address all shellcheck errors
- Document shellcheck learnings - bash shell parameter extension for simple string replacement
- Enable shellcheck in Github Action

**Verification**

All CI Tests run in parallel (Shellcheck + install tests on MacOS/Ubuntu in parallel via strategy):
![image](https://github.com/johannesgiorgis/.dotfiles/assets/4584812/240cad1f-ed43-4f59-a158-33539adb433d)


Shellcheck fails as expected:
![image](https://github.com/johannesgiorgis/.dotfiles/assets/4584812/9529ebb4-834a-4ea3-b139-7620d142437f)

