### PR TITLE
[ci] Speed up Github Action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,12 @@
 name: CI Tests
 on:
   push:
+    branches:
+      - main
     paths:
-      - "*"
+      - "bin/**"
+      - "**yml"
+      - "**.sh"
   pull_request:
     branches:
       - "main" 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,9 +42,9 @@ jobs:
         working-directory: bin
         run: |
           pwd
-          bash doi -t youtube-dl
+          bash doi -t timewarrior
           command -v ansible
-          command -v youtube-dl
+          command -v timew
 
       - name: Check installed versions 
         run: ./.cisupport/post.sh

--- a/bin/doi
+++ b/bin/doi
@@ -22,7 +22,7 @@ fi
 
 if is_ci; then
     echo "Running in CI"
-    ANSIBLE_DIR="../"
+    ANSIBLE_DIR=".."
 else
     ANSIBLE_DIR="${HOME}/.dotfiles"
 fi


### PR DESCRIPTION
Github Action run time increased from ~3 minutes to ~14 minutes. This was due to using the `youtube-dl` role instead of the now defunct `neovim` role. The `youtube-dl` role installed a couple of additional dependencies, which really slowed down the MacOS tests.  `neovim` role became defunct when it was consolidated into the `common-cli` role which includes tons of packages that are installed for multiple OSs.

Ideally, we want a small and quick-to-install role for our CI testing purposes. The `timewarrior` role is well suited as it only includes installing the package via the respective package manager.

**Verification**

Github Action run time went from 13m 58s to 2m 23s 🎉 🤯 

Previous:
![image](https://github.com/johannesgiorgis/.dotfiles/assets/4584812/3617c27a-4168-4996-bdef-db785d5fa126)

New:
![image](https://github.com/johannesgiorgis/.dotfiles/assets/4584812/67d08139-5499-4da1-9a4b-2421663922f7)
