### PR TITLE
fix(ansible): Remove deprecated warn parameter from command module

### DIFF
--- a/roles/cli/common-cli/tasks/broot.yml
+++ b/roles/cli/common-cli/tasks/broot.yml
@@ -23,8 +23,9 @@
         | sudo tee /etc/apt/sources.list.d/azlux.list
     
         sudo wget -O /usr/share/keyrings/azlux-archive-keyring.gpg  https://azlux.fr/repo.gpg
-      args:
-        warn: false
+      # TODO: Test in Linux and remove
+      # args:
+      #   warn: false
     
     - name: COMMON-CLI|BROOT - Install Broot for Debian
       become: "{{ should_be_root }}"

--- a/roles/cli/common-cli/tasks/delta.yml
+++ b/roles/cli/common-cli/tasks/delta.yml
@@ -17,8 +17,9 @@
       shell: >
         curl -s https://api.github.com/repos/dandavison/delta/releases/latest 
         | jq -r '.tag_name'
-      args:
-        warn: false
+      # TODO: Test in Linux and remove
+      # args:
+      #   warn: false
       register: output
     
     - name: COMMON-CLI|DELTA - install {{ output.stdout }} for debian

--- a/roles/cli/common-cli/tasks/jump.yml
+++ b/roles/cli/common-cli/tasks/jump.yml
@@ -16,8 +16,9 @@
       shell: >
         curl -s https://api.github.com/repos/gsamokovarov/jump/releases/latest 
         | jq -r '.name'
-      args:
-        warn: false
+      # TODO: Test in Linux and remove
+      # args:
+      #   warn: false
       register: output
 
     - name: COMMON-CLI|JUMP - Install {{ output.stdout }} Debian package

--- a/roles/cli/common-cli/tasks/noti.yml
+++ b/roles/cli/common-cli/tasks/noti.yml
@@ -22,8 +22,9 @@
       shell: >
         curl -s https://api.github.com/repos/variadico/noti/releases/latest 
         | jq -r '.tag_name'
-      args:
-        warn: false
+      # TODO: Test in Linux and remove
+      # args:
+      #   warn: false
       register: output
     
     - name: COMMON-CLI|NOTI - Download noti {{ output.stdout }} to {{ noti_binary_download_dir.path }}

--- a/roles/infrastructure/asdf/tasks/main.yml
+++ b/roles/infrastructure/asdf/tasks/main.yml
@@ -5,8 +5,6 @@
   shell: >
     curl -s https://api.github.com/repos/asdf-vm/asdf/releases/latest
     | jq -r '.tag_name'
-  args:
-    warn: false
   register: output
 
 - name: ASDF - Clone asdf repository {{ output.stdout }}

--- a/roles/infrastructure/docker/tasks/debian.yml
+++ b/roles/infrastructure/docker/tasks/debian.yml
@@ -72,7 +72,7 @@
     - name: DOCKER - Ensure handlers are notified now to avoid firewall conflicts
       meta: flush_handlers
 
-    - include_tasks: docker-compose.yml
+    - include_tasks: install-docker-compose.yml
 
     - name: DOCKER - Ensure docker users are added to the docker group
       user:

--- a/roles/infrastructure/docker/tasks/install-docker-compose.yml
+++ b/roles/infrastructure/docker/tasks/install-docker-compose.yml
@@ -7,8 +7,9 @@
   shell: >
     curl -s https://api.github.com/repos/docker/compose/releases/latest 
     | jq -r '.tag_name'
-  args:
-    warn: false
+  # TODO: Test in Linux and remove
+  # args:
+  #   warn: false
   register: output
 
 - name: DOCKER-COMPOSE - Install Docker Compose

--- a/roles/infrastructure/linux-terminator/tasks/main.yml
+++ b/roles/infrastructure/linux-terminator/tasks/main.yml
@@ -16,6 +16,7 @@
       # command: "mkdir ~/.config/terminator/plugins"
       # args:
       #   creates: "{{ dotfiles_user_home}}/.config/terminator/plugins"
+      # TODO: Test in Linux and remove
       # warn: false
       file:
         path: ~/.config/terminator/plugins

--- a/roles/software/rambox/tasks/main.yml
+++ b/roles/software/rambox/tasks/main.yml
@@ -16,8 +16,9 @@
       shell: >
         curl -s https://api.github.com/repos/ramboxapp/community-edition/releases/latest 
         | jq -r '.tag_name'
-      args:
-        warn: false
+      # TODO: Test in Linux and remove
+      # args:
+      #   warn: false
       register: output
 
     - name: RAMBOX - Install {{ output.stdout }} (Debian)


### PR DESCRIPTION
Ansible has decided to not show the warnings for the command and shell modules. It was deprecated in v2.11 and removed in v2.14, which led to an error while trying to install certain roles.

![image](https://github.com/johannesgiorgis/.dotfiles/assets/4584812/f83f9b97-3ced-4f36-b4d6-b3aea66bc81b)

**Changes**

- Comment out OR remove the warn parameter from the command module
- Commented out parts are the ones for Linux OS, which need to be tested before being removed.

Closes Issue #10 