### PR TITLE
chore(ansible): Add new roles, organize existing ones

### DIFF
--- a/dotfiles.yml
+++ b/dotfiles.yml
@@ -92,6 +92,7 @@
     - { role: software/google-chrome, tags: [google-chrome] }
     - { role: software/jetbrains-toolbox, tags: [jetbrains-toolbox] }
     - { role: software/joplin, tags: [joplin] }
+    - { role: software/kindle, tags: [kindle] }
     - { role: software/lastpass, tags: [lastpass] }
     - { role: software/lepton, tags: [lepton] }
     - { role: software/linux-blueman, tags: [linux-blueman] }
@@ -119,6 +120,7 @@
     - { role: software/sublime-text, tags: [sublime-text] }
     - { role: software/teamviewer, tags: [teamviewer] }
     - { role: software/todoist, tags: [todoist] }
+    - { role: software/trello, tags: [trello] }
     - { role: software/virtualbox, tags: [virtualbox] }
     - { role: software/vlc, tags: [vlc] }
     - { role: software/vscode, tags: [vscode] }

--- a/roles/infrastructure/git/tasks/main.yml
+++ b/roles/infrastructure/git/tasks/main.yml
@@ -13,7 +13,9 @@
   block:
     - name: GIT - git is present
       package:
-        name: git
+        name: 
+          - git
+          - git-lfs
         state: present
     
     - name: ensure git is configured for users

--- a/roles/infrastructure/macos-infra/tasks/main.yml
+++ b/roles/infrastructure/macos-infra/tasks/main.yml
@@ -40,7 +40,6 @@
         id: "{{ item.id }}"
         state: present
       loop:
-        - { id: 1352778147, name: Bitwarden }
         - { id: 1056643111, name: Clocker }
         - { id: 549083868,  name: DisplayMenu }
 

--- a/roles/software/bitwarden/tasks/main.yml
+++ b/roles/software/bitwarden/tasks/main.yml
@@ -1,14 +1,11 @@
 ---
 # main task for bitwarden
 
-- name: BITWARDEN - Install via homebrew cask (MacOS)
+- name: BITWARDEN|MacOS|Install via mas-cli
   when: ansible_os_family in ["Darwin"]
-  # homebrew_cask:
-  #   name: bitwarden
-  #   state: present
-  debug:
-    msg: "Install from Mac App Store to allow Browser Integration"
-
+  community.general.mas:
+    id: 1352778147  # Bitwarden
+    state: present
 
 
 - name: BITWARDEN|Install for Debian

--- a/roles/software/kindle/tasks/main.yml
+++ b/roles/software/kindle/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+# Amazon Kindle App
+
+- name: KINDLE|MacOS|Install via mas-cli
+  when: ansible_os_family in ["Darwin"]
+  community.general.mas:
+    id: 302584613  # Kindle
+    state: present
+
+
+- name: KINDLE|Debian|Not implemented
+  debug:
+    msg: "TODO: Implement for debian?"

--- a/roles/software/trello/tasks/main.yml
+++ b/roles/software/trello/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+# https://trello.com/
+
+- name: TRELLO|MacOS
+  when: ansible_os_family in ["Darwin"]
+  community.general.mas:
+    id: 1278508951  # Trello
+    state: present
+
+
+- name: TRELLO|Debian|Not implemented
+  debug:
+    msg: "TODO: Implement for debian?"


### PR DESCRIPTION
Previously, MacOS apps installed via mas-cli were all centralized in the `maso-infra` role which no longer made sense with more apps needing to be installed. This commit separates out the non-infra related apps into their own respective roles.

- Add new roles for kindle, trello to install via mas-cli for MacOS
- Move Bitwarden installation into its own existing role for MacOS
- Add git-lfs to git role